### PR TITLE
added 'request bootloader' ability for creality gd32-based firmwares

### DIFF
--- a/src/gd32/Kconfig
+++ b/src/gd32/Kconfig
@@ -14,6 +14,7 @@ config GD32_SELECT
     select HAVE_CHIPID
 #	select HAVE_GPIO_HARD_PWM
     select HAVE_STEPPER_BOTH_EDGE
+    select HAVE_BOOTLOADER_REQUEST
 
 config BOARD_DIRECTORY
     string
@@ -155,6 +156,11 @@ config CLOCK_FREQ
 #config FLASH_START
 #    hex
 #    default 0x08000000
+
+config GD32_DFU_ROM_ADDRESS
+    hex
+    default 0x08000000
+#    default 0x1FFFEC00 if (MACH_GD32E230X6 || MACH_GD32E230X8)
 
 config FLASH_SIZE
     hex

--- a/src/gd32/Makefile
+++ b/src/gd32/Makefile
@@ -44,6 +44,7 @@ $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 # Add source files
 src-y += generic/armcm_boot.c generic/armcm_irq.c 
 src-y += generic/armcm_reset.c generic/crc16_ccitt.c
+src-y += gd32/dfu_reboot.c
 
 src-$(CONFIG_MACH_GD32F30X) += gd32/gd32f30x.c gd32/gd32f30x_gpio.c
 src-$(CONFIG_MACH_GD32F30X) += gd32/gd32e23x_timer.c generic/timer_irq.c

--- a/src/gd32/dfu_reboot.c
+++ b/src/gd32/dfu_reboot.c
@@ -1,0 +1,67 @@
+// Reboot into stm32 ROM dfu bootloader
+//
+// Copyright (C) 2019-2022  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "internal.h" // NVIC_SystemReset
+#include "board/irq.h" // irq_disable
+
+// Many stm32 chips have a USB capable "DFU bootloader" in their ROM.
+// In order to invoke that bootloader it is necessary to reset the
+// chip and jump to a chip specific hardware address.
+//
+// To reset the chip, the dfu_reboot() code sets a flag in memory (at
+// an arbitrary position that is unlikely to be overwritten during a
+// chip reset), and resets the chip.  If dfu_reboot_check() sees that
+// flag on the next boot it will perform a code jump to the ROM
+// address.
+
+// Location of ram address to set internal flag
+#define USB_BOOT_FLAG_ADDR (CONFIG_RAM_START + CONFIG_RAM_SIZE - 512)
+
+// Signature to set in memory to flag that a dfu reboot is requested
+#define USB_BOOT_FLAG 0x4254 // "BT"
+
+// Flag that bootloader is desired and reboot
+void
+dfu_reboot(void)
+{
+    if (!CONFIG_GD32_DFU_ROM_ADDRESS)
+        return;
+    irq_disable();
+#if CONFIG_MACH_GD32F30X
+    BKP_DATA1 = USB_BOOT_FLAG;
+#elif CONFIG_MACH_GD32E23X
+    RTC_BKP1 = USB_BOOT_FLAG;
+#else
+    uint64_t *bflag = (void*)USB_BOOT_FLAG_ADDR;
+    *bflag = USB_BOOT_FLAG;
+#endif
+    NVIC_SystemReset();
+}
+
+// Check if rebooting into system DFU Bootloader
+void
+dfu_reboot_check(void)
+{
+    if (!CONFIG_GD32_DFU_ROM_ADDRESS)
+        return;
+#if CONFIG_MACH_GD32E23X
+    if (RTC_BKP1 != USB_BOOT_FLAG)
+        return;
+    RTC_BKP1 = 0;
+#elif CONFIG_MACH_GD32F30X
+    if (BKP_DATA1 != USB_BOOT_FLAG)
+        return;
+    BKP_DATA1 = 0;
+#else
+    if(*(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
+	return;
+    *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
+#endif
+
+    uint32_t *sysbase = (uint32_t*)CONFIG_GD32_DFU_ROM_ADDRESS;
+    asm volatile("mov sp, %0\n bx %1"
+                 : : "r"(sysbase[0]), "r"(sysbase[1]));
+}

--- a/src/gd32/gd32e23x.c
+++ b/src/gd32/gd32e23x.c
@@ -189,8 +189,16 @@ void systemInit (void)
 }
 
 void
+bootloader_request(void)
+{
+    dfu_reboot();
+}
+
+void
 armcm_main(void)
 {
+        dfu_reboot_check();
+
 	systemInit();
 
 	SCB->VTOR = (uint32_t)VectorTable;

--- a/src/gd32/gd32f30x.c
+++ b/src/gd32/gd32f30x.c
@@ -209,10 +209,17 @@ systemInit(void)
 	systemClock120mHxtal();
 }
 
+void
+bootloader_request(void)
+{
+    dfu_reboot();
+}
 
 void
 armcm_main(void)
 {
+        dfu_reboot_check();
+
 	systemInit();
 	
 	SCB->VTOR = (uint32_t)VectorTable;

--- a/src/gd32/internal.h
+++ b/src/gd32/internal.h
@@ -48,3 +48,7 @@ void gpio_init_output_options_set(uint32_t gpio, uint8_t otype);
 #endif
 
 #endif
+
+// dfu_reboot.c
+void dfu_reboot(void);
+void dfu_reboot_check(void);


### PR DESCRIPTION
Porting stm32 klipper ability of requesting bootloader from within running firmware to GD32 based mcus. mcu_util flasher also supports this functionality now.